### PR TITLE
Return zero for all neutrino types which are unsupported by model

### DIFF
--- a/src/include/nuflux/FluxFunction.h
+++ b/src/include/nuflux/FluxFunction.h
@@ -24,6 +24,9 @@ namespace nuflux{
     NuTauBar = -16,
   };
 
+  /// Determines if particle type is a neutrino
+  bool isNeutrino(ParticleType pdgid);
+
   ///The interface for all neutrino fluxes
   class FluxFunction{
   public:

--- a/src/library/ANFlux.cpp
+++ b/src/library/ANFlux.cpp
@@ -43,7 +43,12 @@ ANFlux::getFlux(ParticleType type, double energy, double cosZenith) const
 
   std::map<ParticleType, boost::shared_ptr<Evaluator> >::const_iterator f = fluxes_.find(type);
   if (f == fluxes_.end()){
-    throw std::runtime_error(name+" does not support particle type "+boost::lexical_cast<std::string>(type));
+    if (isNeutrino(type)) {
+      return 0;
+    } else {
+      throw std::runtime_error( name+" does not support particle type " + 
+                                boost::lexical_cast<std::string>(type));
+    }
   }
   else
     // The current parameterizations are for nu + nubar.

--- a/src/library/FluxFunction.cpp
+++ b/src/library/FluxFunction.cpp
@@ -44,7 +44,11 @@ namespace nuflux{
     
 
   }
-  
+
+  bool isNeutrino(ParticleType pdgid){
+    return ( (pdgid==12) || (pdgid==-12) || (pdgid==14) || (pdgid==-14) || (pdgid==16) || (pdgid==-16) );
+  }
+
   boost::shared_ptr<FluxFunction> makeFlux(const std::string& fluxName){
     if(!detail::registry)
       throw std::invalid_argument("Internal error: Flux registry does not exist");

--- a/src/library/IPLEFlux.cpp
+++ b/src/library/IPLEFlux.cpp
@@ -130,8 +130,16 @@ namespace nuflux{
     double logEnergy=log10(energy);
     dumbHistogram hFluxVCosZenith(-1);
     std::map<ParticleType, std::map<double,CubicSpline> >::const_iterator typeIt=energySplines2D.find(type);
-    if(typeIt==energySplines2D.end())
-      log_fatal_stream("Particle type not found: " << type);
+
+    if(typeIt==energySplines2D.end()){
+      if (isNeutrino(type)) {
+        return 0;
+      } else {
+        throw std::runtime_error( name + " does not support particle type " + 
+                                  boost::lexical_cast<std::string>(type));
+      }
+    }
+
     for(int cz=0; cz<20; cz++){
       double LCosZenith=(10*cz-95)/100.;
       std::map<double,CubicSpline>::const_iterator it;
@@ -164,8 +172,16 @@ namespace nuflux{
     double logEnergy=log10(energy);
     dumbHistogram hFluxVCosZenith(-1);
     std::map<ParticleType, std::map<std::pair<double,double>,CubicSpline> >::const_iterator typeIt=energySplines3D.find(type);
-    if(typeIt==energySplines3D.end())
-      log_fatal_stream("Particle type not found: " << type);
+
+    if(typeIt==energySplines3D.end()){
+      if (isNeutrino(type)) {
+        return 0;
+      } else {
+        throw std::runtime_error( name + " does not support particle type " + 
+                                  boost::lexical_cast<std::string>(type));
+      }
+    }
+
     for(int cz=0; cz<20; cz++){
       double LCosZenith=(10*cz-95)/100.;
       std::map<std::pair<double,double>,CubicSpline>::const_iterator it;

--- a/src/library/LegacyConventionalFlux.cpp
+++ b/src/library/LegacyConventionalFlux.cpp
@@ -49,8 +49,14 @@ namespace nuflux{
   
   double LegacyConventionalFlux::getFlux(ParticleType type, double energy, double cosZenith) const{
     std::map<ParticleType,component>::const_iterator it=components.find(type);
-    if(it==components.end())
-      throw std::runtime_error(name+" does not support particle type "+boost::lexical_cast<std::string>(type));
+    if(it==components.end()){
+      if (isNeutrino(type)) {
+        return 0;
+      } else {
+        throw std::runtime_error( name+" does not support particle type " + 
+                                  boost::lexical_cast<std::string>(type));
+      }
+    }
     return(it->second.getFlux(energy,cosZenith)*kneeCorrection(energy));
   }
   

--- a/src/library/LegacyPromptFlux.cpp
+++ b/src/library/LegacyPromptFlux.cpp
@@ -35,8 +35,14 @@ namespace nuflux{
   
   double LegacyPromptFlux::getFlux(ParticleType type, double energy, double cosZenith) const{
     std::map<ParticleType,component>::const_iterator it=components.find(type);
-    if(it==components.end())
-      throw std::runtime_error(name+" does not support particle type "+boost::lexical_cast<std::string>(type));
+    if(it==components.end()){
+      if (isNeutrino(type)) {
+        return 0;
+      } else {
+        throw std::runtime_error( name+" does not support particle type " + 
+                                  boost::lexical_cast<std::string>(type));
+      }
+    }
     return(it->second.getFlux(energy,cosZenith)*kneeCorrection(energy));
   }
   

--- a/src/library/SplineFlux.cpp
+++ b/src/library/SplineFlux.cpp
@@ -39,8 +39,14 @@ namespace nuflux{
 
   double SimpleSplineFlux::getFlux(ParticleType type, double energy, double cosZenith) const{
     std::map<ParticleType,boost::shared_ptr<photospline::splinetable<>> >::const_iterator it=components.find(type);
-    if(it==components.end())
-      throw std::runtime_error(name+" does not support particle type "+boost::lexical_cast<std::string>(type));
+    if(it==components.end()) {
+      if (isNeutrino(type)) {
+        return 0;
+      } else {
+        throw std::runtime_error( name+" does not support particle type " + 
+                                  boost::lexical_cast<std::string>(type));
+      }
+    }
 
     // Warn the user about coordinates outside of physics extents:
     double le=it->second->lower_extent(0), ue=it->second->upper_extent(0);

--- a/src/library/SplineFlux2.cpp
+++ b/src/library/SplineFlux2.cpp
@@ -69,11 +69,14 @@ namespace nuflux{
     }
     std::map<ParticleType,boost::shared_ptr<photospline::splinetable<>> >
         ::const_iterator it=components.find(type);
-    if(it==components.end())
-      throw std::runtime_error(
-        name+" does not support particle type "
-        +boost::lexical_cast<std::string>(type)
-      );
+    if(it==components.end()){
+      if (isNeutrino(type)) {
+        return 0;
+      } else {
+        throw std::runtime_error( name+" does not support particle type " + 
+                                  boost::lexical_cast<std::string>(type));
+      }
+    }
 
     double coords[2]={log10(energy),std::abs(cosZenith)};
     int centers[2];


### PR DESCRIPTION
The old behavior was to throw on particle type which was not included in the
model. This was causing problems with tau neutrinos where the flux is expected
to be either zero or significantly lower than the other flavors.
This changes it so that the six neturino types will never throw.
The value of zero is used for any particle type wihch is not in the model.

Fixes #15